### PR TITLE
Max record count arg

### DIFF
--- a/esri2gpd/core.py
+++ b/esri2gpd/core.py
@@ -4,12 +4,13 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import requests
+from tenacity import retry
 from arcgis2geojson import arcgis2geojson
 from pkg_resources import packaging
 
 GEOPANDAS_VERSION = packaging.version.parse(gpd.__version__)
 
-
+@retry
 def _get_json_safely(response):
     """
     Check for JSON response errors, and if all clear,

--- a/esri2gpd/core.py
+++ b/esri2gpd/core.py
@@ -26,7 +26,7 @@ def _get_json_safely(response):
     return json
 
 
-def get(url, fields=None, where=None, limit=None, **kwargs):
+def get(url, fields=None, where=None, limit=None, max_record_count=None, **kwargs):
     """
     Scrape features from a ArcGIS Server REST API and return a
     geopandas GeoDataFrame.
@@ -53,7 +53,9 @@ def get(url, fields=None, where=None, limit=None, **kwargs):
     """
     # Get the max record count
     metadata = requests.get(url, params=dict(f="pjson")).json()
-    max_record_count = metadata["maxRecordCount"]
+
+    if not max_record_count:
+        max_record_count = metadata["maxRecordCount"]
 
     # default behavior matches all features
     if where is None:

--- a/esri2gpd/core.py
+++ b/esri2gpd/core.py
@@ -96,15 +96,13 @@ def get(url, fields=None, where=None, limit=None, max_record_count=None, **kwarg
         )
 
     out = []
+
     while params["resultOffset"] < total_size:
 
         remaining = total_size - params["resultOffset"]
-        if remaining < max_record_count:
-            params["resultRecordCount"] = remaining
+        params["resultRecordCount"] = min(remaining, max_record_count)
 
-        # get raw features
-        response = requests.get(queryURL, params=params)
-        json = _get_json_safely(response)
+        json = _get_json_safely(requests.get(queryURL, params=params))
 
         # convert to GeoJSON and save
         geojson = [arcgis2geojson(f) for f in json["features"]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ geopandas = "^0.10.1"
 requests = "^2.26.0"
 arcgis2geojson = "^2.0.1"
 importlib-metadata = "^4.8.1"
+tenacity= "^8.0.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"


### PR DESCRIPTION
By default this package pulls the max number of records allowed by the server.
Some servers have this param set super high, which overloads the server when you try to get that many records.
This PR adds a param to manually set that number and adds retry logic for failing requests.